### PR TITLE
Implement object snapshot&spawn related classes.

### DIFF
--- a/pyckpt/frame.py
+++ b/pyckpt/frame.py
@@ -67,8 +67,8 @@ class FrameCocoon:
         contexts: Dict,
     ):
         captured = interpreter.snapshot(frame, is_leaf, stack_analyzer)
-        nlocals = objects.stub_objects(stub_registry, captured["nlocals"], contexts)
-        stack = objects.stub_objects(stub_registry, captured["stack"], contexts)
+        nlocals = objects.create_snapshot(stub_registry, captured["nlocals"], contexts)
+        stack = objects.create_snapshot(stub_registry, captured["stack"], contexts)
         captured["nlocals"] = nlocals
         captured["stack"] = stack
         if captured["generator"] is not None:
@@ -77,8 +77,8 @@ class FrameCocoon:
         return FrameCocoon(**captured)
 
     def spawn(self, contexts: Dict) -> LiveFrame:
-        nlocals = objects.get_real_objects(self.nlocals, contexts)
-        stack = objects.get_real_objects(self.stack, contexts)
+        nlocals = objects.spawn_objects(self.nlocals, contexts)
+        stack = objects.spawn_objects(self.stack, contexts)
         return LiveFrame(
             func=self.func,
             is_leaf=self.is_leaf,

--- a/pyckpt/objects.py
+++ b/pyckpt/objects.py
@@ -1,8 +1,91 @@
-from typing import Any, Callable, Dict, Generator, List, Tuple, Type
+from types import NoneType
+from typing import Any, Callable, Dict, Generator, List, Tuple, Type, TypeVar
 
-SnapshotMethod = Callable[[Any, Dict], Any]
+SnapshotMethod = Callable[[Any, Dict], "ObjectCocoon"]
 SpawnMethod = Callable[[Any, Dict], Any]
-RegistryHook = Tuple[SnapshotMethod, SpawnMethod]
+RegistryHook = Tuple[SnapshotMethod]
+ContextStateBuilder = Callable[[Dict, "SnapshotContextManager"], Dict]
+SpawnContextBuilder = Callable[["SpawnContextManager", Dict], NoneType]
+
+
+class SnapshotContextManager(dict):
+    def __init__(self):
+        super().__init__()
+        self.state_builder: List[ContextStateBuilder] = []
+        self.spawn_ctx_builders = []
+
+    def build_states(self) -> Dict:
+        states = {}
+        states["spawn_ctx_builder"] = self.spawn_ctx_builders.copy()
+        for builder in self.state_builder:
+            builder(states, self)
+        return states
+
+    def register_state_builder(
+        self,
+        state_builder: ContextStateBuilder,
+        spawn_ctx_builder: SpawnContextBuilder,
+    ):
+        self.state_builder.append(state_builder)
+        self.spawn_ctx_builders.append(spawn_ctx_builder)
+
+    C = TypeVar("C")
+
+    def get_context(self, context_type: C) -> C:
+        """
+        Retrieve a context of the specified type.
+        """
+        return self[context_type]
+
+    def register_context(self, context: Any):
+        """
+        Register a context using its type as the key.
+        """
+        self[type(context)] = context
+
+    def __setitem__(self, _key, _value):
+        raise ValueError(
+            "directly set snapshot contexts is not allowed, use `register_context()` instead"
+        )
+
+
+class SpawnContextManager(dict):
+    def __init__(self):
+        self._object_pool: Dict[int, Any] = {}
+
+    def register_object(self, original_id, obj):
+        self._object_pool[original_id] = obj
+
+    def retrieve_object(self, original_id):
+        if original_id not in self._object_pool:
+            raise ValueError(
+                f"Object with original ID {original_id} not found in the object pool"
+            )
+        return self._object_pool[original_id]
+
+    @staticmethod
+    def build_from_snapshot_states(states: Dict):
+        ctx = SpawnContextManager()
+        spawn_builders: List[SpawnContextBuilder] = states["spawn_ctx_builder"]
+        for spawn_builder in spawn_builders:
+            spawn_builder(ctx, states)
+        return ctx
+
+
+def _spawn_by_original_id(obj: "ObjectCocoon", mgr: SpawnContextManager):
+    return mgr.retrieve_object(obj.states)
+
+
+def snapshot_by_original_id(obj: Any, _mgr: SnapshotContextManager):
+    original_id = id(obj)
+    return ObjectCocoon(original_id, _spawn_by_original_id)
+
+
+def register_type_snapshot_by_id(
+    object_type: Type,
+    registry: Dict[Type, RegistryHook],
+):
+    registry[object_type] = snapshot_by_original_id
 
 
 class NullObjectType:
@@ -44,8 +127,8 @@ def create_snapshot(
             raise NotImplementedError("save generator type")
         obj_type = type(obj)
         if obj_type in registry:
-            snapshot, spawn = registry[obj_type]
-            objects[idx] = ObjectCocoon(snapshot(obj, contexts), spawn)
+            snapshot = registry[obj_type]
+            objects[idx] = snapshot(obj, contexts)
     return objects
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,35 +1,34 @@
 from pyckpt import objects
-from pyckpt.objects import StubObject
 
 
-def test_stub_objects_no_stubs():
+def test_snapshot_objects():
     objs = [1, "2", [3]]
 
-    ret = objects.stub_objects({}, objs, {})
+    ret = objects.create_snapshot({}, objs, {})
 
     for o1, o2 in zip(objs, ret):
         assert o1 is o2
 
 
 def test_stub_objects():
-    def save_str_int(s: str, _):
+    def snapshot_str2int(s: str, _):
         return int(s)
 
-    def load_str_int(a: int, _):
+    def spawn_int2str(a: int, _):
         return f"{a}"
 
-    reg = {str: (save_str_int, load_str_int)}
+    reg = {str: (snapshot_str2int, spawn_int2str)}
 
     objs = ["1", "2", "3"]
 
-    ret = objects.stub_objects(reg, objs, {})
+    ret = objects.create_snapshot(reg, objs, {})
 
     for o1, o2 in zip(objs, ret):
-        assert isinstance(o2, StubObject)
+        assert isinstance(o2, objects.ObjectCocoon)
         assert isinstance(o2.states, int)
         assert int(o1) == o2.states
 
-    rec = objects.get_real_objects(ret, {})
+    rec = objects.spawn_objects(ret, {})
 
     for o1, o2 in zip(objs, rec):
         assert o1 == o2

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -11,13 +11,13 @@ def test_snapshot_objects():
 
 
 def test_stub_objects():
-    def snapshot_str2int(s: str, _):
-        return int(s)
-
     def spawn_int2str(a: int, _):
         return f"{a}"
 
-    reg = {str: (snapshot_str2int, spawn_int2str)}
+    def snapshot_str2int(s: str, _):
+        return objects.ObjectCocoon(int(s), spawn_int2str)
+
+    reg = {str: (snapshot_str2int)}
 
     objs = ["1", "2", "3"]
 
@@ -32,3 +32,105 @@ def test_stub_objects():
 
     for o1, o2 in zip(objs, rec):
         assert o1 == o2
+
+
+def test_snapshot_by_original_id():
+    obj = [1, 2, 3]
+
+    snapshot = objects.snapshot_by_original_id(obj, None)
+    assert isinstance(snapshot, objects.ObjectCocoon)
+    assert snapshot.states == id(obj)
+
+    spawn_context = objects.SpawnContextManager()
+    spawn_context.register_object(id(obj), obj)
+
+    restored_obj = snapshot.spawn_method(snapshot, spawn_context)
+    assert restored_obj is obj
+
+
+def test_spawn_context_manager_retrieve_object():
+    obj = [1, 2, 3]
+    obj_id = id(obj)
+
+    spawn_context = objects.SpawnContextManager()
+    spawn_context.register_object(obj_id, obj)
+
+    retrieved_obj = spawn_context.retrieve_object(obj_id)
+    assert retrieved_obj is obj
+
+    try:
+        spawn_context.retrieve_object(99999)
+    except ValueError as e:
+        assert str(e) == "Object with original ID 99999 not found in the object pool"
+
+
+def test_snapshot_context_manager_build_states():
+    context_manager = objects.SnapshotContextManager()
+
+    def mock_state_builder(states, mgr):
+        assert isinstance(mgr, objects.SnapshotContextManager)
+        states["mock_key"] = "mock_value"
+
+    def mock_spawn_ctx_builder(ctx, states):
+        assert isinstance(ctx, objects.SpawnContextManager)
+        ctx["mock_spawn_key"] = "mock_spawn_value"
+
+    context_manager.register_state_builder(mock_state_builder, mock_spawn_ctx_builder)
+    states = context_manager.build_states()
+
+    assert "mock_key" in states
+    assert states["mock_key"] == "mock_value"
+    assert "spawn_ctx_builder" in states
+    assert len(states["spawn_ctx_builder"]) == 1
+    assert states["spawn_ctx_builder"][0] == mock_spawn_ctx_builder
+
+
+def test_spawn_context_manager_build_from_snapshot_states():
+    states = {
+        "spawn_ctx_builder": [
+            lambda ctx, _: ctx.update({"key1": "value1"}),
+            lambda ctx, _: ctx.update({"key2": "value2"}),
+        ]
+    }
+
+    spawn_context = objects.SpawnContextManager.build_from_snapshot_states(states)
+
+    assert "key1" in spawn_context
+    assert spawn_context["key1"] == "value1"
+    assert "key2" in spawn_context
+    assert spawn_context["key2"] == "value2"
+
+
+def test_spawn_by_original_id():
+    obj = [1, 2, 3]
+    obj_id = id(obj)
+
+    spawn_context = objects.SpawnContextManager()
+    spawn_context.register_object(obj_id, obj)
+
+    cocoon = objects.snapshot_by_original_id(obj, None)
+    restored_obj = cocoon.spawn_method(cocoon, spawn_context)
+
+    assert restored_obj is obj
+
+
+def test_create_snapshot_with_registry():
+    def spawn_list(length, _):
+        return [None] * length
+
+    def snapshot_list(lst, _):
+        return objects.ObjectCocoon(len(lst), spawn_list)
+
+    registry = {list: (snapshot_list)}
+    objs = [[1, 2, 3], [4, 5], [6]]
+
+    snapshots = objects.create_snapshot(registry, objs, {})
+
+    for original, snapshot in zip(objs, snapshots):
+        assert isinstance(snapshot, objects.ObjectCocoon)
+        assert snapshot.states == len(original)
+
+    restored_objs = objects.spawn_objects(snapshots, {})
+    for original, restored in zip(objs, restored_objs):
+        assert len(original) == len(restored)
+        assert all(item is None for item in restored)


### PR DESCRIPTION
1. Add `ObjectCocoon` class to replace original `StubObject`, using `snapshot` and `spawn` api to cosistently manage object capturing.
2. Add `SpawnContextManager` and `SnapshotContextManager` for explicit context management during object capturing/spawning.