### PR TITLE
Basic generator support

### DIFF
--- a/pyckpt/frame.py
+++ b/pyckpt/frame.py
@@ -1,17 +1,39 @@
 import inspect
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from types import FrameType, FunctionType
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
 
 import dill
 
 from pyckpt import interpreter, objects
-from pyckpt.interpreter import ExceptionStates
+from pyckpt.interpreter import ExceptionStates, snapshot_generator
+from pyckpt.objects import SpawnContextManager
 
 Analyzer = Callable[[FunctionType, int, bool], int]
 
 
-class LiveFrame:
+class LiveFrame(ABC):
+    def __init__(self):
+        super().__init__()
+        self._evaluated = False
+
+    @abstractmethod
+    def _evaluate(self): ...
+
+    @abstractmethod
+    def _cleanup(self): ...
+
+    def evaluate(self, ret_val: Any = None, exc_states: Any = None):
+        if self._evaluated:
+            raise ValueError(f"frame {self} already evaluated")
+        self._evaluated = True
+        ret = self._evaluate(ret_val, exc_states)
+        self._cleanup()
+        return ret
+
+
+class LiveFunctionFrame(LiveFrame):
     def __init__(
         self,
         *,
@@ -21,19 +43,17 @@ class LiveFrame:
         nlocals: List[Any],
         stack: List[Any],
     ):
-        self._evaluated = False
+        super().__init__()
         self.is_leaf = is_leaf
         self.func = func
         self.stack = stack
         self.nlocals = nlocals
         self.prev_instr_offset = prev_instr_offset
 
-    def evaluate(
-        self, ret_val=None, exc_states: Optional[ExceptionStates] = None
+    def _evaluate(
+        self, ret_val, exc_states: Optional[ExceptionStates]
     ) -> Tuple[Any, Optional[ExceptionStates]]:
         ret = None
-        if self._evaluated:
-            raise RuntimeError("evaluate frame that is already evaluated.")
         ret = interpreter.eval_frame_at_lasti(
             self.func,
             self.nlocals,
@@ -43,11 +63,32 @@ class LiveFrame:
             self.prev_instr_offset,
             exc_states,
         )
-        # remove local variables
-        del self.nlocals
-        del self.stack
-        self._evaluated = True
         return ret
+
+    def _cleanup(self):
+        del self.is_leaf
+        del self.func
+        del self.prev_instr_offset
+        del self.stack
+        del self.nlocals
+
+
+class LiveGeneratorFrame(LiveFrame):
+    def __init__(self, generator: Generator, is_leaf: bool):
+        super().__init__()
+        self._gen = generator
+        self._is_leaf = is_leaf
+
+    def _evaluate(
+        self, ret_val, exc_states: Optional[ExceptionStates]
+    ) -> Tuple[Any, Optional[ExceptionStates]]:
+        return interpreter.resume_generator(
+            self._gen, self._is_leaf, ret_val, exc_states
+        )
+
+    def _cleanup(self):
+        del self._gen
+        del self._is_leaf
 
 
 @dataclass(frozen=True)
@@ -57,9 +98,10 @@ class FrameCocoon:
     stack: bytes
     nlocals: bytes
     prev_instr_offset: int
+    generator: Optional[Dict]
 
     @staticmethod
-    def from_frame(
+    def snapshot_from_frame(
         frame: FrameType,
         is_leaf: bool,
         stack_analyzer: Analyzer,
@@ -69,23 +111,42 @@ class FrameCocoon:
         captured = interpreter.snapshot(frame, is_leaf, stack_analyzer)
         nlocals = objects.create_snapshot(stub_registry, captured["nlocals"], contexts)
         stack = objects.create_snapshot(stub_registry, captured["stack"], contexts)
-        captured["nlocals"] = nlocals
-        captured["stack"] = stack
-        if captured["generator"] is not None:
-            raise NotImplementedError("snapshot generator is not implemented")
-        del captured["generator"]
-        return FrameCocoon(**captured)
+        generator = captured["generator"]
+        if generator is not None:
+            generator = snapshot_generator(generator)
+        return FrameCocoon(
+            is_leaf=is_leaf,
+            func=captured["func"],
+            nlocals=nlocals,
+            stack=stack,
+            prev_instr_offset=captured["prev_instr_offset"],
+            generator=generator,
+        )
 
-    def spawn(self, contexts: Dict) -> LiveFrame:
+    def _spawn_generator(self, nlocals: List, stack: List) -> LiveGeneratorFrame:
+        gen = interpreter.make_generator(
+            self.generator,
+            {
+                "func": self.func,
+                "prev_instr_offset": self.prev_instr_offset,
+                "nlocals": nlocals,
+                "stack": stack,
+            },
+        )
+        return LiveGeneratorFrame(gen, self.is_leaf)
+
+    def spawn(self, contexts: SpawnContextManager) -> LiveFrame:
         nlocals = objects.spawn_objects(self.nlocals, contexts)
         stack = objects.spawn_objects(self.stack, contexts)
-        return LiveFrame(
-            func=self.func,
-            is_leaf=self.is_leaf,
-            stack=stack,
-            nlocals=nlocals,
-            prev_instr_offset=self.prev_instr_offset,
-        )
+        if self.generator is None:
+            return LiveFunctionFrame(
+                func=self.func,
+                is_leaf=self.is_leaf,
+                stack=stack,
+                nlocals=nlocals,
+                prev_instr_offset=self.prev_instr_offset,
+            )
+        return self._spawn_generator(nlocals, stack)
 
     def clone(self) -> "FrameCocoon":
         return dill.copy(self)

--- a/pyckpt/generator.py
+++ b/pyckpt/generator.py
@@ -1,0 +1,136 @@
+import dataclasses
+from dataclasses import dataclass
+from itertools import chain
+from types import FunctionType
+from typing import Any, Dict, Generator, List, Set, Tuple
+
+from pyckpt import interpreter
+from pyckpt.analyzer import analyze_stack_top
+from pyckpt.interpreter.generator import snapshot_generator, snapshot_generator_frame
+from pyckpt.objects import (
+    CheckpointRestoreContext,
+    CRContextCocoon,
+    SnapshotContextManager,
+    SpawnContextManager,
+    snapshot_as_none,
+    snapshot_by_original_id,
+    snapshot_objects,
+    spawn_objects,
+)
+
+
+@dataclass
+class GeneratorFrameStatesCocoon:
+    func: FunctionType
+    nlocals: List[Any]
+    stack: List[Any]
+    prev_instr_offset: int
+    is_leaf: bool
+
+    @staticmethod
+    def snapshot_from_states(states: Dict, snapshot_contexts: SnapshotContextManager):
+        stack = snapshot_objects(states["stack"], snapshot_contexts)
+        nlocals = snapshot_objects(states["nlocals"], snapshot_contexts)
+        return GeneratorFrameStatesCocoon(
+            func=states["func"],
+            nlocals=nlocals,
+            stack=stack,
+            prev_instr_offset=states["prev_instr_offset"],
+            is_leaf=states["is_leaf"],
+        )
+
+    def spawn(self, spawn_ctxs: SpawnContextManager):
+        states = dataclasses.asdict(self)
+        states["stack"] = spawn_objects(states["stack"], spawn_ctxs)
+        states["nlocals"] = spawn_objects(states["nlocals"], spawn_ctxs)
+        return states
+
+
+GeneratorStates = Dict
+FrameStates = Dict
+Generators = Tuple[int, Tuple[GeneratorStates, FrameStates]]
+
+
+@dataclass
+class GeneratorContext(CheckpointRestoreContext):
+    # used for snapshot
+    suspended_generator: Set[Generator]
+    executing_generator: Set[Generator]
+    # used for spawn
+    suspended_generator_states: List[Generators]
+    executing_generator_states: List[Generators]
+
+    @staticmethod
+    def create_context():
+        return GeneratorContext(
+            suspended_generator=set(),
+            executing_generator=set(),
+            suspended_generator_states=[],
+            executing_generator_states=[],
+        )
+
+    @staticmethod
+    def snapshot_generator(gen: Generator, ctxs: SnapshotContextManager):
+        ctx = ctxs.get_context(GeneratorContext)
+        if interpreter.is_suspended(gen):
+            ctx.suspended_generator.add(gen)
+        elif interpreter.is_executing(gen):
+            ctx.executing_generator.add(gen)
+        else:
+            raise NotImplementedError(
+                "snapshot not-started|cleared generator is not implemented yet"
+            )
+        return snapshot_by_original_id(gen, ctxs)
+
+    def register_snapshot_method(self, snapshot_ctxs: "SnapshotContextManager"):
+        snapshot_ctxs.register_snapshot_method(
+            interpreter.get_generator_type(), GeneratorContext.snapshot_generator
+        )
+        snapshot_ctxs.register_snapshot_method(GeneratorContext, snapshot_as_none)
+
+    @staticmethod
+    def cocoon_spawn(states: Tuple[Generators, Generators]):
+        return GeneratorContext(
+            suspended_generator=None,
+            executing_generator=None,
+            suspended_generator_states=states[0],
+            executing_generator_states=states[1],
+        )
+
+    def snapshot(self, snapshot_ctxs: SnapshotContextManager) -> CRContextCocoon:
+        suspended_generator_states = []
+        for gen in self.suspended_generator:
+            gen_state = snapshot_generator(gen)
+            gen_frame_states = snapshot_generator_frame(gen, analyze_stack_top)
+            gen_frame_states = GeneratorFrameStatesCocoon.snapshot_from_states(
+                gen_frame_states, snapshot_ctxs
+            )
+            suspended_generator_states.append((id(gen), (gen_state, gen_frame_states)))
+
+        executing_generator_states = []
+        for gen in self.executing_generator:
+            gen_state = snapshot_generator(gen)
+            (executing_generator_states.append((id(gen), (gen_state, None))),)
+
+        states = (suspended_generator_states, executing_generator_states)
+        return CRContextCocoon(GeneratorContext.cocoon_spawn, states)
+
+    def spawn(self, spawn_ctxs):
+        for original_id, (gen_states, _) in chain(
+            self.suspended_generator_states, self.executing_generator_states
+        ):
+            gen = interpreter.make_new_generator(
+                gen_states["gi_code"],
+                gen_states["gi_name"],
+                gen_states["gi_qualname"],
+            )
+            spawn_ctxs.register_object(original_id, gen)
+
+    def spawn_epilog(self, spawn_ctxs: "SpawnContextManager"):
+        for original_id, (
+            gen_states,
+            frame_states,
+        ) in self.suspended_generator_states:
+            gen = spawn_ctxs.retrieve_object(original_id)
+            frame_states = frame_states.spawn(spawn_ctxs)
+            interpreter.setup_generator(gen, gen_states, frame_states)

--- a/pyckpt/interpreter/__init__.py
+++ b/pyckpt/interpreter/__init__.py
@@ -8,8 +8,14 @@ from .frame import (
 )
 from .generator import (
     get_generator_type,
+    is_executing,
+    is_suspended,
     make_generator,
+    make_new_generator,
+    resume_generator,
+    setup_generator,
     snapshot_generator,
+    snapshot_generator_frame,
 )
 
 __all__ = [
@@ -22,4 +28,10 @@ __all__ = [
     "make_generator",
     "snapshot_generator",
     "NullObject",
+    "is_suspended",
+    "is_executing",
+    "resume_generator",
+    "snapshot_generator_frame",
+    "make_new_generator",
+    "setup_generator",
 ]

--- a/pyckpt/interpreter/__init__.py
+++ b/pyckpt/interpreter/__init__.py
@@ -1,9 +1,15 @@
 from .frame import (
     ExceptionStates,
+    NullObject,
     eval_frame_at_lasti,
     restore_thread_state,
     save_thread_state,
     snapshot,
+)
+from .generator import (
+    get_generator_type,
+    make_generator,
+    snapshot_generator,
 )
 
 __all__ = [
@@ -12,4 +18,8 @@ __all__ = [
     "restore_thread_state",
     "save_thread_state",
     "snapshot",
+    "get_generator_type",
+    "make_generator",
+    "snapshot_generator",
+    "NullObject",
 ]

--- a/pyckpt/interpreter/cpython.pxd
+++ b/pyckpt/interpreter/cpython.pxd
@@ -103,6 +103,7 @@ cdef extern from *:
     static inline int get_frame_cleared_311() { return FRAME_CLEARED_311; }
     static inline int get_frame_created_311() { return FRAME_CREATED_311; }
     static inline int get_frame_suspended_311() { return FRAME_SUSPENDED_311; }
+    static inline int get_frame_executing_311() { return FRAME_EXECUTING_311; }
     """
 
     # https://github.com/python/cpython/blob/3.11/Include/internal/pycore_frame.h
@@ -112,6 +113,8 @@ cdef extern from *:
         int stacktop
         int owner
         PyObject* localsplus[1]
+        PyInterpreterFrame_311* previous
+        PyFrameObject* frame_obj
 
     cdef PyInterpreterFrame_311* GET_FRAME_311(PyFrameObject* obj)
     cdef void PyFrame_InitializeSpecials_311(PyInterpreterFrame_311 *frame, PyFunctionObject *func, PyObject *locals, int nlocalsplus)
@@ -126,6 +129,7 @@ cdef extern from *:
     cdef inline int get_frame_cleared_311()
     cdef inline int get_frame_created_311()
     cdef inline int get_frame_suspended_311()
+    cdef inline int get_frame_executing_311()
 
 cdef extern from "pyerrors.h":
     cdef PyObject* _PyErr_GetHandledException(PyThreadState* tstate)
@@ -142,10 +146,15 @@ cdef extern from "pystate.h":
     ctypedef struct PyInterpreterState:
         pass
 
+    ctypedef struct _PyCFrame:
+        void* current_frame
+
     ctypedef struct PyThreadState:
+        _PyCFrame* cframe
         PyObject *curexc_type
         PyInterpreterState* interp
         unsigned long thread_id
+        void *exc_info
 
     ctypedef struct PyGILState_STATE:
         pass

--- a/pyckpt/interpreter/frame.pxd
+++ b/pyckpt/interpreter/frame.pxd
@@ -1,0 +1,2 @@
+cdef void init_locals_and_stack(void* f, list nlocals, list stack, int co_nlocalsplus)
+cdef object _snapshot_frame(void* frame_ptr, int is_leaf, object analyzer)

--- a/pyckpt/interpreter/frame.pyi
+++ b/pyckpt/interpreter/frame.pyi
@@ -10,8 +10,8 @@ __test__: dict
 
 class NullObjectType: ...
 
-def eval_frame_at_lasti(func_obj: FunctionType, nlocals: list[Any], stack: list[Any], is_leaf: bool, ret_value: Any = ..., prev_instr_offset=..., exc_states: ExceptionStates | None = ...) -> tuple[Any, ExceptionStates]:
-    """eval_frame_at_lasti(func_obj: FunctionType, nlocals: List[Any], stack: List[Any], is_leaf: bool, ret_value: Any = None, prev_instr_offset=-1, exc_states: Optional[ExceptionStates] = None) -> Tuple[Any, ExceptionStates]"""
+def eval_frame_at_lasti(func_obj: FunctionType, nlocals: list[Any], stack: list[Any], is_leaf: bool, ret_value: Any = ..., prev_instr_offset=..., exc_states: ExceptionStates | None = ...) -> tuple[Any, ExceptionStates | None]:
+    """eval_frame_at_lasti(func_obj: FunctionType, nlocals: List[Any], stack: List[Any], is_leaf: bool, ret_value: Any = None, prev_instr_offset=-1, exc_states: Optional[ExceptionStates] = None) -> Tuple[Any, Optional[ExceptionStates]]"""
 def frame_specials_size() -> Any:
     """frame_specials_size()"""
 def get_generator(frame: FrameType) -> Any:

--- a/pyckpt/interpreter/frame.pyi
+++ b/pyckpt/interpreter/frame.pyi
@@ -1,0 +1,28 @@
+from builtins import FrameType, FunctionType
+from threading import Thread
+from typing import Analyzer, Any, ExceptionStates
+
+CALL_CODES: list
+CALL_INSTR_NAMES: list
+NullObject: NullObjectType
+__pyx_capi__: dict
+__test__: dict
+
+class NullObjectType: ...
+
+def eval_frame_at_lasti(func_obj: FunctionType, nlocals: list[Any], stack: list[Any], is_leaf: bool, ret_value: Any = ..., prev_instr_offset=..., exc_states: ExceptionStates | None = ...) -> tuple[Any, ExceptionStates]:
+    """eval_frame_at_lasti(func_obj: FunctionType, nlocals: List[Any], stack: List[Any], is_leaf: bool, ret_value: Any = None, prev_instr_offset=-1, exc_states: Optional[ExceptionStates] = None) -> Tuple[Any, ExceptionStates]"""
+def frame_specials_size() -> Any:
+    """frame_specials_size()"""
+def get_generator(frame: FrameType) -> Any:
+    """get_generator(frame: FrameType)"""
+def is_call_instr(opcode: int) -> Any:
+    """is_call_instr(opcode: int)"""
+def restore_exception(states: ExceptionStates) -> Any:
+    """restore_exception(states: ExceptionStates)"""
+def restore_thread_state(state: dict) -> Any:
+    """restore_thread_state(state: Dict)"""
+def save_thread_state(thread: Thread) -> Any:
+    """save_thread_state(thread: Thread)"""
+def snapshot(frame_obj: FrameType, is_leaf: bool, analyzer: Analyzer) -> dict:
+    """snapshot(frame_obj: FrameType, is_leaf: bool, analyzer: Analyzer) -> Dict"""

--- a/pyckpt/interpreter/frame.pyx
+++ b/pyckpt/interpreter/frame.pyx
@@ -4,7 +4,6 @@ from types import CodeType, FrameType, FunctionType, TracebackType
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type
 from libc.stdlib cimport malloc, free
 from cpython.ref cimport PyObject, Py_INCREF
-from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
 from threading import Thread
 from itertools import chain
 from pyckpt.interpreter.cpython cimport *
@@ -130,7 +129,7 @@ def eval_frame_at_lasti(
     ret_value: Any = None,
     prev_instr_offset = -1,
     exc_states: Optional[ExceptionStates] = None,
-) -> Tuple[Any, ExceptionStates]:
+) -> Tuple[Any, Optional[ExceptionStates]]:
     cdef PyFunctionObject* func = <PyFunctionObject*>func_obj
     cdef PyThreadState* state = PyThreadState_GET()
     cdef PyCodeObject * code = <PyCodeObject*> func.func_code;
@@ -159,7 +158,6 @@ def eval_frame_at_lasti(
     cdef PyObject* result = _PyEval_EvalFrameDefault(state, frame, do_exc)
     if result == NULL:
         exc_states = _fetch_exception()
-        PyErr_Clear()
         return None, exc_states
     free(frame)
     return <object> result, None

--- a/pyckpt/interpreter/generator.pyi
+++ b/pyckpt/interpreter/generator.pyi
@@ -1,13 +1,25 @@
+from pyckpt.interpreter.frame import NullObject as NullObject, fetch_exception as fetch_exception, restore_exception as restore_exception
 from typing import Any, Generator
 
 __test__: dict
 
+class ClearFrame(Exception): ...
+
 def get_generator_type() -> type:
     """get_generator_type() -> Type"""
+def is_executing(generator: Generator) -> Any:
+    """is_executing(generator: Generator)"""
 def is_suspended(generator: Generator) -> Any:
     """is_suspended(generator: Generator)"""
 def make_generator(gen_states: dict, frame_states: dict) -> Any:
     """make_generator(gen_states: Dict, frame_states: Dict)"""
+def resume_generator(generator, is_leaf, ret_val=..., exc_states=...) -> Any:
+    """resume_generator(generator, is_leaf, ret_val=None, exc_states=None)
+    resume_generator_pop(generator: Generator, is_leaf: bool, ret_val: Any) -> Tuple[Any, Optional[ExceptionStates]]
+
+            Mimic CPython's behavior for generator evaluation
+            See gen_send_ex2() in https://github.com/python/cpython/blob/3.11/Objects/genobject.c
+    """
 def snapshot_generator(generator: Generator) -> Any:
     """snapshot_generator(generator: Generator)"""
 def snapshot_generator_frame(generator, analyzer) -> Any:

--- a/pyckpt/interpreter/generator.pyi
+++ b/pyckpt/interpreter/generator.pyi
@@ -13,6 +13,8 @@ def is_suspended(generator: Generator) -> Any:
     """is_suspended(generator: Generator)"""
 def make_generator(gen_states: dict, frame_states: dict) -> Any:
     """make_generator(gen_states: Dict, frame_states: Dict)"""
+def make_new_generator(func_code, func_name, func_qualname) -> Any:
+    """make_new_generator(func_code, func_name, func_qualname)"""
 def resume_generator(generator, is_leaf, ret_val=..., exc_states=...) -> Any:
     """resume_generator(generator, is_leaf, ret_val=None, exc_states=None)
     resume_generator_pop(generator: Generator, is_leaf: bool, ret_val: Any) -> Tuple[Any, Optional[ExceptionStates]]
@@ -20,6 +22,8 @@ def resume_generator(generator, is_leaf, ret_val=..., exc_states=...) -> Any:
             Mimic CPython's behavior for generator evaluation
             See gen_send_ex2() in https://github.com/python/cpython/blob/3.11/Objects/genobject.c
     """
+def setup_generator(generator: Generator, gen_states: dict, frame_states: dict) -> Any:
+    """setup_generator(generator: Generator, gen_states: Dict, frame_states: Dict)"""
 def snapshot_generator(generator: Generator) -> Any:
     """snapshot_generator(generator: Generator)"""
 def snapshot_generator_frame(generator, analyzer) -> Any:

--- a/pyckpt/interpreter/generator.pyi
+++ b/pyckpt/interpreter/generator.pyi
@@ -1,0 +1,14 @@
+from typing import Any, Generator
+
+__test__: dict
+
+def get_generator_type() -> type:
+    """get_generator_type() -> Type"""
+def is_suspended(generator: Generator) -> Any:
+    """is_suspended(generator: Generator)"""
+def make_generator(gen_states: dict, frame_states: dict) -> Any:
+    """make_generator(gen_states: Dict, frame_states: Dict)"""
+def snapshot_generator(generator: Generator) -> Any:
+    """snapshot_generator(generator: Generator)"""
+def snapshot_generator_frame(generator, analyzer) -> Any:
+    """snapshot_generator_frame(generator, analyzer)"""

--- a/pyckpt/interpreter/generator.pyx
+++ b/pyckpt/interpreter/generator.pyx
@@ -1,0 +1,129 @@
+# cython: embedsignature=True, embedsignature.format=python
+import sys
+
+from cpython.ref cimport Py_INCREF, PyTypeObject
+from typing import Dict, Generator, Type
+from pyckpt.interpreter.cpython cimport *
+from pyckpt.interpreter.cpython cimport _Py_CODEUNIT
+from pyckpt.interpreter.frame cimport init_locals_and_stack, _snapshot_frame
+
+
+if (3, 11) <= sys.version_info <= (3, 12):
+    from pyckpt.interpreter.cpython cimport PyInterpreterFrame_311 as _PyInterpreterFrame
+    from pyckpt.interpreter.cpython cimport PyFrame_InitializeSpecials_311 as _PyFrame_InitializeSpecials
+    from pyckpt.interpreter.cpython cimport get_frame_cleared_311 as get_frame_cleared
+    from pyckpt.interpreter.cpython cimport get_frame_created_311 as get_frame_created
+    from pyckpt.interpreter.cpython cimport get_frame_suspended_311 as get_frame_suspended
+    from pyckpt.interpreter.cpython cimport get_frame_owned_by_generator_311 as get_frame_owned_by_generator
+else:
+    raise SystemError(f"unsupported python version: {sys.version_info}")
+
+cdef extern from "Python.h":
+    """
+    # define New_Gen(slots) PyObject_GC_NewVar(PyGenObject, &PyGen_Type, slots)
+    """
+
+    ctypedef struct _PyErr_StackItem:
+        PyObject* exc_value
+        _PyErr_StackItem *previous_item
+
+    ctypedef struct PyGenObject:
+        PyCodeObject *gi_code;
+        PyObject *gi_weakreflist;
+        PyObject *gi_name;
+        PyObject *gi_qualname;
+        PyObject *gi_origin_or_finalizer;
+        char gi_hooks_inited;
+        char gi_closed;
+        char gi_running_async;
+        _PyErr_StackItem gi_exc_state;
+        int gi_frame_state;
+        _PyInterpreterFrame *gi_iframe;
+
+    cdef PyGenObject* New_Gen(int slots)
+
+    cdef PyTypeObject PyGen_Type
+
+cdef PyGenObject* new_generator(PyFunctionObject *func):
+    cdef PyCodeObject* code = <PyCodeObject*> func.func_code
+    cdef int slots = code.co_nlocalsplus + code.co_stacksize;
+    cdef PyGenObject* gen = New_Gen(slots)
+    if gen == NULL:
+        return NULL
+    if func.func_name == NULL or func.func_qualname == NULL:
+        return NULL
+    gen.gi_frame_state = get_frame_cleared()
+    gen.gi_code = code
+    gen.gi_exc_state.previous_item = NULL
+    gen.gi_exc_state.exc_value = NULL
+    gen.gi_weakreflist = NULL
+    gen.gi_name = func.func_name
+    gen.gi_qualname = func.func_qualname
+    Py_INCREF(<object> gen.gi_code)
+    Py_INCREF(<object> gen.gi_name)
+    Py_INCREF(<object> gen.gi_qualname)
+    PyObject_GC_Track(<PyObject*> gen)
+    return gen
+
+
+cdef inline int no_exception(PyObject* exc_value):
+    return exc_value == NULL or exc_value == Py_None
+
+def snapshot_generator(generator: Generator):
+    cdef PyGenObject* gen = <PyGenObject*> generator
+    # if gen.gi_exc_state.exc_value != NULL:
+    if not no_exception(gen.gi_exc_state.exc_value):
+        raise NotImplementedError("exception stack for generators")
+
+    Py_INCREF(<object> gen.gi_code)
+    Py_INCREF(<object> gen.gi_name)
+    Py_INCREF(<object> gen.gi_qualname)
+    Py_INCREF(<object> gen.gi_frame_state)
+
+    return {
+        "gi_code"        : <object> gen.gi_code,
+        "gi_name"        : <object> gen.gi_name,
+        "gi_qualname"    : <object> gen.gi_qualname,
+        "gi_frame_state" : <int>    gen.gi_frame_state,
+        "suspended": gen.gi_frame_state == get_frame_suspended(),
+    }
+
+cpdef snapshot_generator_frame(object generator, object analyzer):
+    cdef PyGenObject* gen = <PyGenObject*> generator
+    if gen.gi_frame_state != get_frame_suspended():
+        raise ValueError("snapshot non-suspended generator is not supported")
+    return _snapshot_frame(gen.gi_iframe, False, analyzer)
+
+def make_generator(gen_states: Dict, frame_states: Dict):
+    cdef PyFunctionObject* func = <PyFunctionObject*> frame_states["func"]
+    # N.B. The generator somehow should own a strong reference to the funcobject.
+    # This is different from frame evaluation apis where the caller owns the reference.
+    # Logically, the generator should own everything it could `touch`,and it can touch
+    # the funcobject through the _PyInterpreterFrame C struct (which is not a PyObject!)
+    # So just make the GC happy :)
+    Py_INCREF(<object> func)
+    cdef PyGenObject* gen = new_generator(func)
+    cdef _PyInterpreterFrame* frame = gen.gi_iframe
+    cdef PyCodeObject* code = <PyCodeObject*> func.func_code
+
+    nlocals = frame_states["nlocals"]
+    prev_instr_offset = frame_states["prev_instr_offset"]
+    _PyFrame_InitializeSpecials(
+        frame, func, <PyObject*> nlocals, code.co_nlocalsplus
+    )
+    frame.prev_instr = &(<_Py_CODEUNIT*>(code.co_code_adaptive))[prev_instr_offset]
+    frame.owner = get_frame_owned_by_generator()
+    gen.gi_frame_state = gen_states["gi_frame_state"]
+    stack = frame_states["stack"]
+    init_locals_and_stack(frame, nlocals, stack, code.co_nlocalsplus)
+    if gen == NULL:
+        raise RuntimeError("failed to make new generator")
+    return <object> gen
+
+def is_suspended(generator: Generator):
+    return (<PyGenObject*> generator).gi_frame_state == get_frame_suspended()
+
+def get_generator_type() -> Type:
+    # `type` objects are not dynamically allocated
+    # hence no incref here
+    return <object> &PyGen_Type

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+from tkinter import W
 from typing import List
 
 from Cython.Build import cythonize
@@ -22,7 +23,7 @@ def platform_module() -> List[str]:
 def interpreter_module() -> List[Extension]:
     version = f"{sys.version_info.major}_{sys.version_info.minor}"
     if version == "3_11":
-        return ["pyckpt/interpreter/frame.pyx"]
+        return ["pyckpt/interpreter/frame.pyx", "pyckpt/interpreter/generator.pyx"]
     else:
         raise RuntimeError(
             f"unsupported CPython version:\
@@ -40,7 +41,9 @@ setup(
     version="0.0.0",
     ext_modules=cythonize(
         cython_modules,
-        compiler_directives={"language_level": "3"},
+        compiler_directives={
+            "language_level": "3",
+        },
     ),
     packages=["pyckpt"],
     requires=["Cython"],

--- a/tests/debug.py
+++ b/tests/debug.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+sys.path.append(os.getcwd())
+sys.path.append(os.path.join(os.getcwd(), "platform"))

--- a/tests/interpreter/test_interpreter_frame.py
+++ b/tests/interpreter/test_interpreter_frame.py
@@ -7,8 +7,8 @@ from typing import Generator
 import pytest
 from bytecode import Bytecode, Instr
 
+from pyckpt.interpreter import NullObject
 from pyckpt.interpreter import frame as _frame
-from pyckpt.objects import NullObject
 
 
 def test_eval_no_args():
@@ -97,10 +97,9 @@ def test_snapshot_stack():
     foo()
 
 
-def test_snapshot_generator():
+def test_snapshot_generator_from_frame():
     def foo():
         frame = inspect.currentframe()
-        # frame.snapshot(frame, True, FixedStackAnalyzer(4))["stack"]
         yield frame
 
     gen = foo()
@@ -108,9 +107,8 @@ def test_snapshot_generator():
 
     frame = next(gen)
     assert isinstance(frame, FrameType)
-    g = _frame._get_generator(frame)
+    g = _frame.get_generator(frame)
     assert isinstance(g, Generator)
-
     assert gen is g
 
 

--- a/tests/interpreter/test_interpreter_generator.py
+++ b/tests/interpreter/test_interpreter_generator.py
@@ -1,0 +1,87 @@
+import inspect
+from types import FrameType
+from typing import Generator
+
+import dill
+import pytest
+
+from pyckpt.analyzer import analyze_stack_top
+from pyckpt.interpreter import frame as _frame
+from pyckpt.interpreter import generator as _generator
+
+
+def test_snapshot_generator():
+    def foo():
+        frame = inspect.currentframe()
+        yield frame
+
+    gen = foo()
+    assert isinstance(gen, Generator)
+    captured = _generator.snapshot_generator(gen)
+
+    assert captured["gi_code"] is foo.__code__
+    assert "foo" in captured["gi_name"]
+    assert "foo" in captured["gi_qualname"]
+
+
+def test_make_generator():
+    def foo():
+        frame = inspect.currentframe()
+        yield frame
+        yield 42
+
+    gen = foo()
+    frame = next(gen)
+    gen_ret = _frame.get_generator(frame)
+    assert gen_ret is gen
+
+    gen_states = _generator.snapshot_generator(gen_ret)
+    frame_states = _frame.snapshot(frame, False, analyze_stack_top)
+    for i, obj in enumerate(frame_states["stack"]):
+        if isinstance(obj, FrameType):
+            frame_states["stack"][i] = None
+    for i, obj in enumerate(frame_states["nlocals"]):
+        if isinstance(obj, FrameType):
+            frame_states["nlocals"][i] = None
+    del frame_states["generator"]
+    frame_states = dill.copy(frame_states)
+    gen_new = _generator.make_generator(gen_states, frame_states)
+    assert isinstance(gen_new, Generator)
+    assert _generator.is_suspended(gen_new)
+    gen_states = _generator.snapshot_generator(gen_ret)
+    with pytest.raises(StopIteration):
+        assert next(gen_new) == 42
+        next(gen_new)
+    with pytest.raises(StopIteration):
+        assert next(gen) == 42
+        next(gen)
+
+
+def test_get_generator_type():
+    def test():
+        yield 42
+
+    gen = test()
+    gen_type = _generator.get_generator_type()
+    assert isinstance(gen, gen_type)
+    assert type(gen) is gen_type
+
+
+def test_snapshot_generator_frame():
+    def foo():
+        yield 41
+        yield 42
+
+    gen = foo()
+    assert next(gen) == 41
+
+    gen_states = _generator.snapshot_generator(gen)
+    assert gen_states["suspended"]
+    frame_states = _generator.snapshot_generator_frame(gen, analyze_stack_top)
+    new_gen = _generator.make_generator(gen_states, frame_states)
+    with pytest.raises(StopIteration):
+        assert next(gen) == 42
+        next(gen)
+    with pytest.raises(StopIteration):
+        assert next(new_gen) == 42
+        next(new_gen)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,173 @@
+import inspect
+import unittest
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyckpt.analyzer import analyze_stack_top
+from pyckpt.frame import FrameCocoon, LiveFunctionFrame
+from pyckpt.generator import (
+    GeneratorContext,
+    GeneratorFrameStatesCocoon,
+)
+from pyckpt.objects import CRContextCocoon, SnapshotContextManager, SpawnContextManager
+
+
+class TestGeneratorFrameStatesCocoon(unittest.TestCase):
+    def setUp(self):
+        self.states = {
+            "func": lambda x: x,
+            "nlocals": [1, 2, 3],
+            "stack": [4, 5, 6],
+            "prev_instr_offset": 10,
+            "is_leaf": True,
+        }
+
+    @patch("pyckpt.generator.snapshot_objects")
+    def test_snapshot_from_states(self, mock_snapshot_objects):
+        mock_snapshot_objects.side_effect = lambda x, _: x
+        snapshot_ctxs = SnapshotContextManager()
+        cocoon = GeneratorFrameStatesCocoon.snapshot_from_states(
+            self.states, snapshot_ctxs
+        )
+        self.assertEqual(cocoon.func, self.states["func"])
+        self.assertEqual(cocoon.nlocals, self.states["nlocals"])
+        self.assertEqual(cocoon.stack, self.states["stack"])
+        self.assertEqual(cocoon.prev_instr_offset, self.states["prev_instr_offset"])
+        self.assertEqual(cocoon.is_leaf, self.states["is_leaf"])
+
+    @patch("pyckpt.generator.spawn_objects")
+    def test_spawn(self, mock_spawn_objects):
+        mock_spawn_objects.side_effect = lambda x, _: x
+        cocoon = GeneratorFrameStatesCocoon(**self.states)
+        spawn_ctxs = MagicMock(spec=SpawnContextManager)
+        spawned_states = cocoon.spawn(spawn_ctxs)
+        self.assertEqual(spawned_states["func"], self.states["func"])
+        self.assertEqual(spawned_states["nlocals"], self.states["nlocals"])
+        self.assertEqual(spawned_states["stack"], self.states["stack"])
+        self.assertEqual(
+            spawned_states["prev_instr_offset"], self.states["prev_instr_offset"]
+        )
+        self.assertEqual(spawned_states["is_leaf"], self.states["is_leaf"])
+
+
+class TestGeneratorContext(unittest.TestCase):
+    def setUp(self):
+        self.suspended_generators = [MagicMock()]
+        self.executing_generators = [MagicMock()]
+        self.context = GeneratorContext(
+            suspended_generator_states=[],
+            executing_generator_states=[],
+            suspended_generator=self.suspended_generators,
+            executing_generator=self.executing_generators,
+        )
+
+    @patch("pyckpt.generator.snapshot_generator")
+    @patch("pyckpt.generator.snapshot_generator_frame")
+    @patch("pyckpt.generator.GeneratorFrameStatesCocoon.snapshot_from_states")
+    def test_snapshot(
+        self,
+        mock_snapshot_from_states,
+        mock_snapshot_generator_frame,
+        mock_snapshot_generator,
+    ):
+        gen_states = {
+            "gi_code": "code",
+            "gi_name": "name",
+            "gi_qualname": "qualname",
+        }
+        snapshot_frame_states = MagicMock()
+        mock_snapshot_generator.return_value = gen_states
+        mock_snapshot_generator_frame.return_value = {"stack": [], "nlocals": []}
+        mock_snapshot_from_states.return_value = snapshot_frame_states
+        cocoon = self.context.snapshot(None)
+
+        self.assertIsInstance(cocoon, CRContextCocoon)
+
+    @patch("pyckpt.generator.interpreter.make_new_generator")
+    def test_spawn(self, mock_make_new_generator):
+        mock_make_new_generator.return_value = MagicMock()
+        spawn_ctxs = MagicMock(spec=SpawnContextManager)
+        self.context.suspended_generator_states = [
+            (
+                1,
+                (
+                    {"gi_code": "code", "gi_name": "name", "gi_qualname": "qualname"},
+                    None,
+                ),
+            )
+        ]
+        self.context.spawn(spawn_ctxs)
+        mock_make_new_generator.assert_called_once_with(
+            self.context.suspended_generator_states[0][1][0]["gi_code"],
+            self.context.suspended_generator_states[0][1][0]["gi_name"],
+            self.context.suspended_generator_states[0][1][0]["gi_qualname"],
+        )
+        new_generator = mock_make_new_generator.return_value
+        spawn_ctxs.register_object.assert_called_once_with(
+            self.context.suspended_generator_states[0][0],
+            new_generator,
+        )
+
+    @patch("pyckpt.generator.interpreter.setup_generator")
+    def test_spawn_epilog(self, mock_setup_generator):
+        spawn_ctxs = MagicMock(spec=SpawnContextManager)
+        frame_states_mock = MagicMock()
+        frame_states_mock.spawn.return_value = {}
+        self.context.suspended_generator_states = [
+            (
+                1,
+                (
+                    {"gi_code": "code", "gi_name": "name", "gi_qualname": "qualname"},
+                    frame_states_mock,
+                ),
+            )
+        ]
+        self.context.spawn_epilog(spawn_ctxs)
+        mock_setup_generator.assert_called_once()
+
+
+def test_snapshot_with_local_generator():
+    def generator_function():
+        yield 41
+        yield 42
+        return 43
+
+    def test_function_with_generator():
+        local_gen = generator_function()
+        next(local_gen)  # Advance the generator to its first yield
+        ctxs = SnapshotContextManager()
+        gen_ctx = GeneratorContext.create_context()
+        ctxs.register_context(gen_ctx)
+        frame = FrameCocoon.snapshot_from_frame(
+            inspect.currentframe(),
+            is_leaf=False,
+            stack_analyzer=analyze_stack_top,
+            contexts=ctxs,
+        )
+        if frame:
+            frame = frame.clone()
+            return frame, ctxs.snapshot_contexts()
+
+        return local_gen
+
+    cocoon, contexts = test_function_with_generator()
+    # Ensure the cocoon is correctly created
+    assert isinstance(cocoon, FrameCocoon)
+    spawn_ctxs = SpawnContextManager.build_from_context_snapshot(contexts)
+    live_frame = cocoon.spawn(spawn_ctxs)
+    spawn_ctxs.epilogue()
+
+    assert isinstance(live_frame, LiveFunctionFrame)
+
+    # Evaluate the generator frame
+    gen, exc_states = live_frame._evaluate(None, None)
+    assert exc_states is None
+    assert isinstance(gen, Generator)
+    assert next(gen) == 42
+
+    with pytest.raises(StopIteration) as e:
+        next(gen)
+
+    assert e.value.value == 43

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,10 +1,17 @@
+from unittest.mock import Mock
+
 from pyckpt import objects
+from pyckpt.objects import (
+    CheckpointRestoreContext,
+    CRContextCocoon,
+    SnapshotContextManager,
+)
 
 
 def test_snapshot_objects():
     objs = [1, "2", [3]]
-
-    ret = objects.create_snapshot({}, objs, {})
+    ctxs = SnapshotContextManager()
+    ret = objects.snapshot_objects(objs, ctxs)
 
     for o1, o2 in zip(objs, ret):
         assert o1 is o2
@@ -21,7 +28,8 @@ def test_stub_objects():
 
     objs = ["1", "2", "3"]
 
-    ret = objects.create_snapshot(reg, objs, {})
+    ctxs = SnapshotContextManager(registry=reg)
+    ret = objects.snapshot_objects(objs, ctxs)
 
     for o1, o2 in zip(objs, ret):
         assert isinstance(o2, objects.ObjectCocoon)
@@ -64,43 +72,6 @@ def test_spawn_context_manager_retrieve_object():
         assert str(e) == "Object with original ID 99999 not found in the object pool"
 
 
-def test_snapshot_context_manager_build_states():
-    context_manager = objects.SnapshotContextManager()
-
-    def mock_state_builder(states, mgr):
-        assert isinstance(mgr, objects.SnapshotContextManager)
-        states["mock_key"] = "mock_value"
-
-    def mock_spawn_ctx_builder(ctx, states):
-        assert isinstance(ctx, objects.SpawnContextManager)
-        ctx["mock_spawn_key"] = "mock_spawn_value"
-
-    context_manager.register_state_builder(mock_state_builder, mock_spawn_ctx_builder)
-    states = context_manager.build_states()
-
-    assert "mock_key" in states
-    assert states["mock_key"] == "mock_value"
-    assert "spawn_ctx_builder" in states
-    assert len(states["spawn_ctx_builder"]) == 1
-    assert states["spawn_ctx_builder"][0] == mock_spawn_ctx_builder
-
-
-def test_spawn_context_manager_build_from_snapshot_states():
-    states = {
-        "spawn_ctx_builder": [
-            lambda ctx, _: ctx.update({"key1": "value1"}),
-            lambda ctx, _: ctx.update({"key2": "value2"}),
-        ]
-    }
-
-    spawn_context = objects.SpawnContextManager.build_from_snapshot_states(states)
-
-    assert "key1" in spawn_context
-    assert spawn_context["key1"] == "value1"
-    assert "key2" in spawn_context
-    assert spawn_context["key2"] == "value2"
-
-
 def test_spawn_by_original_id():
     obj = [1, 2, 3]
     obj_id = id(obj)
@@ -121,10 +92,11 @@ def test_create_snapshot_with_registry():
     def snapshot_list(lst, _):
         return objects.ObjectCocoon(len(lst), spawn_list)
 
-    registry = {list: (snapshot_list)}
     objs = [[1, 2, 3], [4, 5], [6]]
 
-    snapshots = objects.create_snapshot(registry, objs, {})
+    registry = {list: (snapshot_list)}
+    ctxs = SnapshotContextManager(registry=registry)
+    snapshots = objects.snapshot_objects(objs, ctxs)
 
     for original, snapshot in zip(objs, snapshots):
         assert isinstance(snapshot, objects.ObjectCocoon)
@@ -134,3 +106,63 @@ def test_create_snapshot_with_registry():
     for original, restored in zip(objs, restored_objs):
         assert len(original) == len(restored)
         assert all(item is None for item in restored)
+
+
+def _create_cr_context_mock(states=None):
+    mock_context = Mock(spec=CheckpointRestoreContext)
+
+    def snapshot_behavior(snapshot_ctxs):
+        return CRContextCocoon(spawn_method=lambda states: mock_context, states=states)
+
+    mock_context.snapshot.side_effect = snapshot_behavior
+    return mock_context
+
+
+def test_snapshot_context_manager_snapshot_contexts():
+    s = "hello"
+    mock_context = _create_cr_context_mock(s)
+    snapshot_manager = objects.SnapshotContextManager(
+        {type(mock_context): mock_context}
+    )
+
+    snapshots = snapshot_manager.snapshot_contexts()
+    assert len(snapshots) == 1
+    assert isinstance(snapshots[0], objects.CRContextCocoon)
+    assert snapshots[0].states is s
+
+
+def test_spawn_context_manager_build_from_context_snapshot():
+    mock_context = _create_cr_context_mock()
+    snapshot_manager = objects.SnapshotContextManager(
+        {type(mock_context): mock_context}
+    )
+    snapshots = snapshot_manager.snapshot_contexts()
+    spawn_manager = objects.SpawnContextManager.build_from_context_snapshot(snapshots)
+
+    assert isinstance(spawn_manager, objects.SpawnContextManager)
+    assert type(mock_context) in spawn_manager._contexts
+    mock_context.spawn.assert_called_once_with(spawn_manager)
+
+
+def test_spawn_context_manager_register_and_retrieve_object():
+    obj = [1, 2, 3]
+    obj_id = id(obj)
+
+    spawn_manager = objects.SpawnContextManager()
+    spawn_manager.register_object(obj_id, obj)
+
+    retrieved_obj = spawn_manager.retrieve_object(obj_id)
+    assert retrieved_obj is obj
+
+    try:
+        spawn_manager.retrieve_object(99999)
+    except ValueError as e:
+        assert str(e) == "Object with original ID 99999 not found in the object pool"
+
+
+def test_spawn_context_manager_epilogue():
+    mock_context = _create_cr_context_mock()
+    spawn_manager = objects.SpawnContextManager({type(mock_context): mock_context})
+    spawn_manager.epilogue()
+
+    mock_context.spawn_epilog.assert_called_once()


### PR DESCRIPTION
> Currently only suspened and executing generators are supported,  not-started and cleared frames should be added in the future.

1. Refactor object snapshot&spawn apis(`Context` and `ContextManager` are now explicitly typed).
2. Overall, the generator spawn is split into two phases, first create new cleared generators as stub(before any frame is spawned), then setup their frame states(during the frame spawn).
3. There may be confusion that **suspended generators** are setup in the `epilogue()` of `SpawnContextManager`, and **executing generators** are setup by construction of its corresponding `LiveFrame`.